### PR TITLE
Improve code generation when importing library resources to use the s…

### DIFF
--- a/source/Boardwalk-Tests/WADeploymentAwareFileMetadataLibraryTest.class.st
+++ b/source/Boardwalk-Tests/WADeploymentAwareFileMetadataLibraryTest.class.st
@@ -8,6 +8,12 @@ Class {
 }
 
 { #category : #tests }
+WADeploymentAwareFileMetadataLibraryTest >> testDefaultCacheDuration [
+
+	self assert: WATestingFileMetadataLibrary defaultCacheDuration equals: ( Duration days: 365 )
+]
+
+{ #category : #tests }
 WADeploymentAwareFileMetadataLibraryTest >> testDeployFiles [
 
 	self
@@ -77,4 +83,38 @@ WADeploymentAwareFileMetadataLibraryTest >> testJavascriptGeneration [
 WADeploymentAwareFileMetadataLibraryTest >> testLibraryName [
 
 	self assert: WATestingFileMetadataLibrary libraryName equals: 'testing'
+]
+
+{ #category : #tests }
+WADeploymentAwareFileMetadataLibraryTest >> testMetadataSourceCodeForFileNamedCompiledAtServingContentAt [
+
+	self
+		assert:
+			( WATestingFileMetadataLibrary
+				metadataSourceCodeForFileNamed: 'css/willow.css'
+				compiledAt: #cssWillowCss
+				servingContentAt: #cssWillowCssContent )
+		equals:  'cssWillowCss
+
+	^ WAFileLibraryResource
+		filepath: ''css/willow.css''
+		mimeType: WAMimeType textCss
+		cacheDuration: self class defaultCacheDuration
+		contents: (GRDelayedSend receiver: self selector: #cssWillowCssContent)'
+]
+
+{ #category : #tests }
+WADeploymentAwareFileMetadataLibraryTest >> testMimeTypeInstantiationCodeFor [
+
+	self
+		assert: ( WATestingFileMetadataLibrary mimeTypeInstantiationCodeFor: WAMimeType textJavascript )
+			equals: 'WAMimeType textJavascript';
+		assert: ( WATestingFileMetadataLibrary mimeTypeInstantiationCodeFor: WAMimeType textCss )
+			equals: 'WAMimeType textCss';
+		assert: ( WATestingFileMetadataLibrary mimeTypeInstantiationCodeFor: WAMimeType applicationJavascript )
+			equals: 'WAMimeType applicationJavascript';
+		assert:
+			( WATestingFileMetadataLibrary
+				mimeTypeInstantiationCodeFor: ( WAMimeType main: 'application' sub: 'x-smalltalk' ) )
+			equals: '(WAMimeType main: ''application'' sub: ''x-smalltalk'')'
 ]

--- a/source/Boardwalk/WADeploymentAwareFileMetadataLibrary.class.st
+++ b/source/Boardwalk/WADeploymentAwareFileMetadataLibrary.class.st
@@ -7,6 +7,33 @@ Class {
 	#category : #'Boardwalk-WebApplication'
 }
 
+{ #category : #'file addition' }
+WADeploymentAwareFileMetadataLibrary class >> addFileNamed: filename contents: aByteArrayOrString [
+
+	<ignoreForCoverage>
+	| selector code contentSelector |
+
+	selector := self asSelector: filename.
+	contentSelector := selector , 'Content'.
+	code := self
+		metadataSourceCodeForFileNamed: filename
+		compiledAt: selector
+		servingContentAt: contentSelector.
+	GRPlatform current compile: code into: self classified: self methodCategory , ' metadata'.
+	( self isBinary: filename )
+		ifTrue: [ self compileBinary: aByteArrayOrString selector: contentSelector ]
+		ifFalse: [ self compileText: aByteArrayOrString selector: contentSelector ]
+]
+
+{ #category : #Accessing }
+WADeploymentAwareFileMetadataLibrary class >> defaultCacheDuration [
+
+	"Since this libraries are intended to be immutable including the version 
+	in the path to serve we can cache the responses the maximum allowed time"
+
+	^ Duration seconds: 31536000
+]
+
 { #category : #Accessing }
 WADeploymentAwareFileMetadataLibrary class >> folderName [
 
@@ -47,6 +74,34 @@ WADeploymentAwareFileMetadataLibrary class >> isForDevelopment [
 WADeploymentAwareFileMetadataLibrary class >> libraryName [
 
 	^ self subclassResponsibility
+]
+
+{ #category : #'file addition' }
+WADeploymentAwareFileMetadataLibrary class >> metadataSourceCodeForFileNamed: filename compiledAt: selector servingContentAt: contentSelector [
+
+	| mimeType |
+
+	mimeType := self mimetypeFor: ( filename copyAfterLast: $. ).
+	^ String
+		streamContents: [ :stream | 
+			stream
+				nextPutAll: selector; cr;
+				cr;
+				tab; nextPutAll: '^ WAFileLibraryResource'; cr;
+				tab; tab; nextPutAll: 'filepath: '''; nextPutAll: filename; nextPutAll: ''''; cr;
+				tab; tab; nextPutAll: 'mimeType: '; nextPutAll: ( self mimeTypeInstantiationCodeFor: mimeType ); cr;
+				tab; tab; nextPutAll: 'cacheDuration: self class defaultCacheDuration'; cr;
+				tab; tab; nextPutAll: 'contents: (GRDelayedSend receiver: self selector: #'; nextPutAll: contentSelector; nextPutAll: ')'
+			]
+]
+
+{ #category : #'file addition' }
+WADeploymentAwareFileMetadataLibrary class >> mimeTypeInstantiationCodeFor: mimeType [
+
+	^ ( WAMimeType class allSelectorsInProtocol: #convenience ) , #(#applicationJavascript)
+		detect: [ :selector | ( WAMimeType perform: selector ) = mimeType ]
+		ifFound: [ :selector | 'WAMimeType <1s>' expandMacrosWith: selector greaseString ]
+		ifNone: [ '(WAMimeType main: ''<1s>'' sub: ''<2s>'')' expandMacrosWith: mimeType main with: mimeType sub ]
 ]
 
 { #category : #Accessing }

--- a/source/Boardwalk/WADeploymentAwareFileMetadataLibrary.class.st
+++ b/source/Boardwalk/WADeploymentAwareFileMetadataLibrary.class.st
@@ -28,7 +28,7 @@ WADeploymentAwareFileMetadataLibrary class >> addFileNamed: filename contents: a
 { #category : #Accessing }
 WADeploymentAwareFileMetadataLibrary class >> defaultCacheDuration [
 
-	"Since this libraries are intended to be immutable including the version 
+	"Since these libraries are intended to be immutable including the version 
 	in the path to serve we can cache the responses the maximum allowed time"
 
 	^ Duration seconds: 31536000

--- a/source/Boardwalk/WAMimeType.extension.st
+++ b/source/Boardwalk/WAMimeType.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #WAMimeType }
+
+{ #category : #'*Boardwalk' }
+WAMimeType class >> applicationJavascript [
+
+	^ self main: 'application' sub: 'javascript'
+]


### PR DESCRIPTION
…horthands in mime type creation and to send the message defaultCacheDuration instead of hardcoding the value in every resource method.

Change defaultCacheDuration to one year for subclasses of WADeploymentAwareFileMetadataLibrary