### PR TITLE
35 uuuid assigner

### DIFF
--- a/source/Boardwalk-Tests/IdentifierAssignerTest.class.st
+++ b/source/Boardwalk-Tests/IdentifierAssignerTest.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : #IdentifierAssignerTest,
 	#superclass : #TestCase,
 	#instVars : [
-		'idOptional'
+		'idOptional',
+		'nextId'
 	],
 	#category : #'Boardwalk-Tests-WebApplication'
 }
@@ -16,14 +17,16 @@ IdentifierAssignerTest >> id: anId [
 { #category : #'test support' }
 IdentifierAssignerTest >> nextId [
 
-	^ '123'
+	nextId := nextId + 1.
+	^ nextId - 1
 ]
 
 { #category : #running }
 IdentifierAssignerTest >> setUp [
 
 	super setUp.
-	idOptional := Optional unused
+	idOptional := Optional unused.
+	nextId := 1
 ]
 
 { #category : #test }
@@ -44,7 +47,7 @@ IdentifierAssignerTest >> testBeRequired [
 	assigner := IdentifierAssigner prefixedBy: 'table'.
 	assigner beRequired.
 	assigner applyTo: self on: self.
-	idOptional withContentDo: [ :id | self assert: id equals: 'table-123' ] ifUnused: [ self fail ]
+	idOptional withContentDo: [ :id | self assert: id equals: 'table-1' ] ifUnused: [ self fail ]
 ]
 
 { #category : #test }
@@ -70,10 +73,10 @@ IdentifierAssignerTest >> testBeRequiredBeforeAndAfterApplyingIsAllowed [
 	assigner := IdentifierAssigner prefixedBy: 'table'.
 	assigner beRequired.
 	assigner applyTo: self on: self.
-	idOptional withContentDo: [ :id | self assert: id equals: 'table-123' ] ifUnused: [ self fail ].
+	idOptional withContentDo: [ :id | self assert: id equals: 'table-1' ] ifUnused: [ self fail ].
 
 	assigner beRequired.
-	idOptional withContentDo: [ :id | self assert: id equals: 'table-123' ] ifUnused: [ self fail ]
+	idOptional withContentDo: [ :id | self assert: id equals: 'table-1' ] ifUnused: [ self fail ]
 ]
 
 { #category : #test }
@@ -82,7 +85,7 @@ IdentifierAssignerTest >> testIdentifierOn [
 	| assigner |
 
 	assigner := IdentifierAssigner prefixedBy: 'table'.
-	self assert: ( assigner identifierOn: self ) equals: 'table-123'
+	self assert: ( assigner identifierOn: self ) equals: 'table-1'
 ]
 
 { #category : #test }
@@ -100,5 +103,18 @@ IdentifierAssignerTest >> testPrefixedBy [
 	| assigner |
 
 	assigner := IdentifierAssigner prefixedBy: 'table'.
-	self assert: ( assigner identifierOn: self ) equals: 'table-123'
+	self assert: ( assigner identifierOn: self ) equals: 'table-1'
+]
+
+{ #category : #test }
+IdentifierAssignerTest >> testStoredIdDoesNotKeepCounterFromIncreasing [
+
+	| assigner |
+
+	assigner := IdentifierAssigner prefixedBy: 'table'.
+	self assert: nextId equals: 1.
+	self assert: ( assigner identifierOn: self ) equals: 'table-1'.
+	self assert: nextId equals: 2.
+	self assert: ( assigner identifierOn: self ) equals: 'table-1'.
+	self assert: nextId equals: 3
 ]

--- a/source/Boardwalk/IdentifierAssigner.class.st
+++ b/source/Boardwalk/IdentifierAssigner.class.st
@@ -16,7 +16,10 @@ Class {
 { #category : #'Instance Creation' }
 IdentifierAssigner class >> prefixedBy: aPrefix [
 
-	AssertionChecker enforce: [ aPrefix notEmpty ] because: 'The supplied prefix cannot be empty' raising: InstanceCreationFailed.
+	AssertionChecker
+		enforce: [ aPrefix notEmpty ]
+		because: 'The supplied prefix cannot be empty'
+		raising: InstanceCreationFailed.
 
 	^ self new initializePrefixedBy: aPrefix
 ]
@@ -28,21 +31,6 @@ IdentifierAssigner >> applyTo: aComponent on: aCanvas [
 	wasApplied := true
 ]
 
-{ #category : #accessing }
-IdentifierAssigner >> assignedIdentifier [
-
-	self beRequired.
-	^ identifierOptional
-		withContentDo: [ :identifier | identifier ]
-		ifUnused: [ | identifier |
-
-			identifier := '<1s>-<2s>' expandMacrosWith: prefix with: UUID new asString.
-			HTMLAsserter new assertIsValidIdentifier: identifier.
-			identifierOptional := Optional containing: identifier.
-			identifier
-			]
-]
-
 { #category : #configuring }
 IdentifierAssigner >> beRequired [
 
@@ -50,10 +38,22 @@ IdentifierAssigner >> beRequired [
 		unless: isRequired
 ]
 
-{ #category : #configuring }
+{ #category : #accessing }
 IdentifierAssigner >> identifierOn: aCanvas [
 
-	^ self assignedIdentifier
+	self beRequired.
+	^ identifierOptional
+		withContentDo: [ :identifier | 
+			aCanvas nextId.
+			identifier
+			]
+		ifUnused: [ | identifier |
+
+			identifier := '<1s>-<2s>' expandMacrosWith: prefix with: aCanvas nextId.
+			HTMLAsserter new assertIsValidIdentifier: identifier.
+			identifierOptional := Optional containing: identifier.
+			identifier
+			]
 ]
 
 { #category : #initialization }

--- a/source/Boardwalk/IdentifierAssigner.class.st
+++ b/source/Boardwalk/IdentifierAssigner.class.st
@@ -49,7 +49,7 @@ IdentifierAssigner >> identifierOn: aCanvas [
 			]
 		ifUnused: [ | identifier |
 
-			identifier := '<1s>-<2s>' expandMacrosWith: prefix with: aCanvas nextId.
+			identifier := '<1s>-<2s>' expandMacrosWith: prefix greaseString with: aCanvas nextId greaseString.
 			HTMLAsserter new assertIsValidIdentifier: identifier.
 			identifierOptional := Optional containing: identifier.
 			identifier

--- a/source/Boardwalk/IdentifierAssigner.class.st
+++ b/source/Boardwalk/IdentifierAssigner.class.st
@@ -28,6 +28,21 @@ IdentifierAssigner >> applyTo: aComponent on: aCanvas [
 	wasApplied := true
 ]
 
+{ #category : #accessing }
+IdentifierAssigner >> assignedIdentifier [
+
+	self beRequired.
+	^ identifierOptional
+		withContentDo: [ :identifier | identifier ]
+		ifUnused: [ | identifier |
+
+			identifier := '<1s>-<2s>' expandMacrosWith: prefix with: UUID new asString.
+			HTMLAsserter new assertIsValidIdentifier: identifier.
+			identifierOptional := Optional containing: identifier.
+			identifier
+			]
+]
+
 { #category : #configuring }
 IdentifierAssigner >> beRequired [
 
@@ -38,16 +53,7 @@ IdentifierAssigner >> beRequired [
 { #category : #configuring }
 IdentifierAssigner >> identifierOn: aCanvas [
 
-	self beRequired.
-	^ identifierOptional
-		withContentDo: [ :identifier | identifier ]
-		ifUnused: [ | identifier |
-
-			identifier := '<1s>-<2s>' expandMacrosWith: prefix greaseString with: aCanvas nextId greaseString.
-			HTMLAsserter new assertIsValidIdentifier: identifier.
-			identifierOptional := Optional containing: identifier.
-			identifier
-			]
+	^ self assignedIdentifier
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
Fixes #35 
Prevented the requirement to use UUID by just increasing the canvas id when the assigner was already assigned. This effectively prevents reuse of an id in different sessions, which anyway can only occur for identifier assigners that are kept from one request to another because of an instance variable in an application that has submitted and thus generated a key/session for its URL. 